### PR TITLE
Update calibration program in .ino

### DIFF
--- a/DataLogger_2025.ino
+++ b/DataLogger_2025.ino
@@ -302,16 +302,19 @@ void updateIMUData() {
 void calibrateIMU() {
   const int CALIB_SAMPLES = 25;
   float temp;
-  float accXCalibBuffer[CALIB_SAMPLE_COUNT];
-  float accYCalibBuffer[CALIB_SAMPLE_COUNT];  
-  float accZCalibBuffer[CALIB_SAMPLE_COUNT];
-  float gyroXCalibBuffer[CALIB_SAMPLE_COUNT];
-  float gyroYCalibBuffer[CALIB_SAMPLE_COUNT];
-  float gyroZCalibBuffer[CALIB_SAMPLE_COUNT];
+  float accXCalibBuffer[CALIB_SAMPLES];
+  float accYCalibBuffer[CALIB_SAMPLES];  
+  float accZCalibBuffer[CALIB_SAMPLES];
+  float gyroXCalibBuffer[CALIB_SAMPLES];
+  float gyroYCalibBuffer[CALIB_SAMPLES];
+  float gyroZCalibBuffer[CALIB_SAMPLES];
 
   for (int i = 0;  i < CALIB_SAMPLES; i++) {
     // Waits until all data is ready for collection
-    while(!IMU.accelerationAvailable() || !IMU.gyroscocpeAvailable()));
+    while (!IMU.accelerationAvailable() || !IMU.gyroscopeAvailable()) {
+      delay(1);          // sleep to avoid a busy-loop
+    }
+
     IMU.readAcceleration(accX, accY, accZ);
     IMU.readGyroscope(gyroX, gyroY, gyroZ);
 
@@ -324,8 +327,8 @@ void calibrateIMU() {
   }
     
   // Bubble Sorting to find the Median (for each sensor)
-  for (int i = 0; i < CALIB_SAMPLE_COUNT - 1; i++) {
-    for (int j = 0; j < CALIB_SAMPLE_COUNT - i - 1; j++) {
+  for (int i = 0; i < CALIB_SAMPLES - 1; i++) {
+    for (int j = 0; j < CALIB_SAMPLES - i - 1; j++) {
       // accX
       if (accXCalibBuffer[j] > accXCalibBuffer[j + 1]) {
         temp = accXCalibBuffer[j];
@@ -363,12 +366,12 @@ void calibrateIMU() {
         gyroZCalibBuffer[j + 1] = temp;
       }
     }
-
-   // Calculate the offsets
-   int middle = CALIB_SAMPLES / 2;
-   accX_off = accXCalibBuffer[middle];  accY_off = accYCalibBuffer[middle];  accZ_off = accZCalibBuffer[middle] - 1;
-   gyroX_off = gyroXCalibBuffer[middle];  gyroY_off = gyroYCalibBuffer[middle];  gyroZ_off = gyroZCalibBuffer[middle];
   }
+
+  // Calculate the offsets
+  int middle = CALIB_SAMPLES / 2;
+  accX_off = accXCalibBuffer[middle];  accY_off = accYCalibBuffer[middle];  accZ_off = accZCalibBuffer[middle] - 1;
+  gyroX_off = gyroXCalibBuffer[middle];  gyroY_off = gyroYCalibBuffer[middle];  gyroZ_off = gyroZCalibBuffer[middle];
 }
 
 // === Barometer Data Update ===


### PR DESCRIPTION
Polished my previous commit regarding the IMU calibration:
- Fixed inefficiencies such as the offsets calculated inside the loop
- Fixed the variable name mistake in accXCalibBuffer[CALIB_SAMPLES];
- Avoided a busy-loop in "while (!IMU.accelerationAvailable() || !IMU.gyroscopeAvailable())"
- Fixed two typos in "while(!IMU.accelerationAvailable() || !IMU.gyroscopeAvailable()));"

Potential future patches:
- "paltitude = 44330 * (1 - pow(pressure / 101.325, 1 / 5.255));" should make an integer division (integer) / (float). Consider this effect and maybe add 1.0 / 5.255?