### PR TITLE
Update .ino (Magnetometer calibration)

### DIFF
--- a/DataLogger_2025.ino
+++ b/DataLogger_2025.ino
@@ -23,6 +23,11 @@
 #define SCL_ESP    6
 #define BUCKET_SIZE 5
 
+// === Calibration constants ===
+#define CALIB_SAFETY_CHECK 1    // boolean
+#define CALIB_DEBUG 0
+#define CALIB_MIN_ACCURACY 60   // Recommended: 60. Maximum: 90
+
 TwoWire WireESP(SDA_ESP, SCL_ESP);  // Second I2C bus on Nano BLE Sense Rev2
 
 // Create GPS parser
@@ -96,6 +101,7 @@ float magX_off  = 0, magY_off  = 0, magZ_off  = 0;
 float preAccX, preAccY, preAccZ = 0;
 float preGyroX, preGyroY, preGyroZ = 0;
 float preMagX, preMagY, preMagZ;
+bool retryCalibration = 0;
 
 
 // ====== Mode and Buffer Settings FOR ESP Sending ======
@@ -120,11 +126,14 @@ String generateDataLine();
 void logToSD();
 void calibrateIMU(); 
 void calibrateIMU2();
+bool fullSpanCalibration(int16_t, int16_t, int16_t, int16_t, int16_t, int16_t);
 void generateFilename(); 
 void readNextLineFromSD();
 
 // button logic and voltage divider!
+void onButtonPress();
 bool buttonReleased();
+void waitForButtonPressed();
 void updateBatteryVoltage();
 void checkBattery();
 void startLog();
@@ -237,27 +246,27 @@ void setup() {
   generateFilename();
 
   //============ IMU CALIBIRATION. =========//
-  Serial.println("Start IMU Offset Calibration? Press button");
-  displayTwoLines("Offset Calibration?", "Press button", u8g2_font_ncenB10_tr, 10, 20);
-
-  while(!buttonInterruptFlag) {
-    yield();    // Nano BLE 33, RTOS native instructions. Doesn't starve the processor with delay(500) and ensures proper waiting of the button pressed (even though our current button doesnt have that problem).
-  }
-  buttonInterruptFlag = false; 
-
+  // Accelerometer & Gyroscope, stationary
+  Serial.println("IMU Calibration 1 (Acc & Gyro): Press button");
+  displayTwoLines("IMU Calibration 1:", "Press button", u8g2_font_ncenB10_tr, 10, 20);
+  waitForButtonPressed();
+  Serial.println("Press, once again, to end calibation 1");
+  displayTwoLines("End?", "Press button", u8g2_font_ncenB10_tr, 10, 20);
+  waitForButtonPressed();
+  
   calibrateIMU();
 
-  delay(2000);
-  //IMU MAG Calibiration
-  Serial.println("Start IMU MAG Calibration? Press button");
-  displayTwoLines("MAG Calibration?", "Press button", u8g2_font_ncenB10_tr, 10, 20);
-
-  while(!buttonInterruptFlag) {
-    yield();    // Nano BLE 33, RTOS native instructions. Doesn't starve the processor with delay(500) and ensures proper waiting of the button pressed (even though our current button doesnt have that problem).
-  }
-  buttonInterruptFlag = false; 
-
-  calibrateIMU2();
+  // Magnetometer, victory dance!
+  Serial.println("IMU Calibration 2 (Magnetometer): Press button");
+  displayTwoLines("Magnet. Calibration:", "Press button", u8g2_font_ncenB10_tr, 10, 20);
+  waitForButtonPressed();
+  do {
+    if (retryCalibration == 1) {
+      Serial.println("Calibration failed... Trying again");
+      displayTwoLines("CALIB FAIL...", "Trying Again", u8g2_font_ncenB10_tr, 10, 20);
+    }
+    calibrateIMU2();
+  } while (retryCalibration);
 
   Serial.println("IMU calibration complete.");  
   displayTwoLines("IMU calibration", "complete.", u8g2_font_ncenB10_tr, 10, 20);
@@ -397,6 +406,7 @@ void updateIMUData() {
     IMU.readMagneticField(preMagX, preMagY, preMagZ);
     magX = preMagX - magX_off;
     magY = preMagY - magY_off;
+    magZ = preMagZ - magZ_off;
   }
 }
 
@@ -537,6 +547,13 @@ void onButtonPress() {
     buttonInterruptFlag = true;
     lastEdge = millis();
   }
+}
+
+void waitForButtonPressed() {
+  while(!buttonInterruptFlag) {
+    yield();    // Nano BLE 33, RTOS native instructions. Doesn't starve the processor with delay(500) and ensures proper waiting of the button pressed (even though our current button doesnt have that problem).
+  }
+  buttonInterruptFlag = false; 
 }
 
 String generateDataLine() {
@@ -760,9 +777,6 @@ void calibrateIMU() {
     // Store the values 
     accXCalibBuffer[i] = accX;  accYCalibBuffer[i] = accY;  accZCalibBuffer[i] = accZ;  
     gyroXCalibBuffer[i] = gyroX; gyroYCalibBuffer[i] = gyroY;  gyroZCalibBuffer[i] = gyroZ; 
-
-    // Accelerometer and gyrospcope output data rate is fixed at 99.84 Hz (10ms)
-    delay(11); // CHANGE THIS USING YIELD
   }
     
   // Bubble Sorting to find the Median (for each sensor)
@@ -812,18 +826,22 @@ void calibrateIMU() {
   accX_off = accXCalibBuffer[middle];  accY_off = accYCalibBuffer[middle];  accZ_off = accZCalibBuffer[middle] - 1;
   gyroX_off = gyroXCalibBuffer[middle];  gyroY_off = gyroYCalibBuffer[middle];  gyroZ_off = gyroZCalibBuffer[middle];
 
-  printIMUOffsetsAndReadings();
+  if (CALIB_DEBUG) {
+    printIMUOffsetsAndReadings();
+  }
 }
 
 // === IMU Calibration (Magnetometer) ===
 void calibrateIMU2() {
-  // Calculate this buffer depending on the maximum sampling rate + maximum calibration time that I will use.
-  const int MAGNET_CALIB_SAMPLES = 6000;   // Considering the max 100 Hz sampling rate and 60s of calibration (far beyond the needed, probably)
+  // Positioning time: max 20'' per orientation. Total 6 x 20'' = 2'
+  // Wait in each position to sample: 5''. Total 6 x 5'' = 30''
+  // Magnetometer output data rate is fixed at 20 Hz.
+  const int MAGNET_CALIB_SAMPLES = 3000;
 
-  // It would be slightly better to have "float" buffers, but make sure of the IMU sampling rate. Two int16_t buffers take 23 kB (9% of RAM) temporarily.
+  // Three int16_t buffers take 18 kB (7% of RAM) temporarily. (Ideally they'd be float buffers but the Thread's assigned stack gets exceeded)
   int16_t magnXCalibBuffer[MAGNET_CALIB_SAMPLES];
   int16_t magnYCalibBuffer[MAGNET_CALIB_SAMPLES];
-  //float magnZCalibBuffer[MAGNET_CALIB_SAMPLES]; // Probably not needed. Only if Six-Axis Calibration method is used.
+  int16_t magnZCalibBuffer[MAGNET_CALIB_SAMPLES]; // Only if Six-Axis Calibration method is used.
 
   Serial.println("END Calibration? Press button");
   displayTwoLines("END Calibration?", "Press button", u8g2_font_ncenB10_tr, 10, 20);
@@ -837,37 +855,55 @@ void calibrateIMU2() {
 
     IMU.readMagneticField(magX, magY, magZ);
 
-    magnXCalibBuffer[j] = magX;  magnYCalibBuffer[j] = magY;
+    magnXCalibBuffer[j] = magX;  magnYCalibBuffer[j] = magY; magnZCalibBuffer[j] = magZ;
     j++;
   }
 
-  // ADD CODE THAT MAKES SURE THAT THE INITIALIZATION WAS LONG ENOUGH AND THAT ALL POSITIVE AND NEGATIVE VALUES ARE RECORDED. ELSE, TRY AGAIN
+  // Find maximums and minimums. The other values may be necessary
+  int16_t xMin = magnXCalibBuffer[0]; int16_t yMin = magnYCalibBuffer[0]; int16_t zMin = magnZCalibBuffer[0];
+  int16_t xMax = xMin;                int16_t yMax = yMin;                int16_t zMax = zMin;
 
-  // Find maximums and minimums. The other values will be necessary to double check correct initialization
-  int16_t xMin = magnXCalibBuffer[0];
-  int16_t xMax = xMin;
-  int16_t yMin = magnYCalibBuffer[0];
-  int16_t yMax = yMin;
+  for (int i = 0; i < j-1; ++i) {
+      int16_t x = magnXCalibBuffer[i]; int16_t y = magnYCalibBuffer[i]; int16_t z = magnZCalibBuffer[i];
 
-  for (int i = 1; i < j-1; ++i) {
-      int16_t x = magnXCalibBuffer[i];
-      int16_t y = magnYCalibBuffer[i];
-
-      if (x < xMin) xMin = x;
-      if (x > xMax) xMax = x;
-
-      if (y < yMin) yMin = y;
-      if (y > yMax) yMax = y;
+      if (x < xMin) {xMin = x;} else if (x > xMax) {xMax = x;}
+      if (y < yMin) {yMin = y;} else if (y > yMax) {yMax = y;}
+      if (z < zMin) {zMin = z;} else if (z > zMax) {zMax = z;}
   }
 
   // Hard-iron offsets
   float bx = 0.5f * (xMax + xMin);
   float by = 0.5f * (yMax + yMin);
+  float bz = 0.5f * (zMax + zMin);
 
-  magX_off  = bx, magY_off  = by;
+  magX_off = bx; magY_off = by; magZ_off = bz;
+
+  // (DEBUGGING) Min & Max axis display
+  if (CALIB_DEBUG) {
+      Serial.print(F("xMax: ")); Serial.print(xMax); Serial.print(F(" // xMin: ")); Serial.println(xMin);
+      Serial.print(F("yMax: ")); Serial.print(yMax); Serial.print(F(" // yMin: ")); Serial.println(yMin);
+      Serial.print(F("zMax: ")); Serial.print(zMax); Serial.print(F(" // zMin: ")); Serial.println(zMin);
+  }
+
+  // Calibration reliability check-up
+  if (CALIB_SAFETY_CHECK == 1) {
+    // If calibration lasted less than 30'' or there's a lack of positive || negative values recorded, then the calibration isn't reliable
+    if (j < 600 || fullSpanCalibration(xMin, xMax, yMin, yMax, zMin, zMax)) {
+      retryCalibration = 1;
+    }
+  }
 } // buffers go out of scope here, RAM reclaimed automatically
 
+// Helper function. Checks that the recorded range sits on (ACCURACY)% of the expected span range. Otherwise, the calibration isn't reliable.
+bool fullSpanCalibration(int16_t xMin, int16_t xMax, int16_t yMin, int16_t yMax, int16_t zMin, int16_t zMax) {
+  if (((xMax - xMin) < CALIB_MIN_ACCURACY) || ((yMax - yMin) < CALIB_MIN_ACCURACY) || ((zMax - zMin) < CALIB_MIN_ACCURACY)) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
 
+// (DEBUGGING) Helper function
 void printIMUOffsetsAndReadings() {
   Serial.println("=== IMU Offsets ===");
   Serial.print("accX_off: "); Serial.print(accX_off);


### PR DESCRIPTION
Completed the Magnetometer calibration, prepared for 6-Axis method. After calibration, magX, magY, magZ are NOT zero.

- Included constants, such as "CALIB_SAFETY_CHECK", logic and functions for debugging and quality-check purposes.

@Shiro-01, the code was tested on a simplified version, although I couldn't run the whole application due to the <CircularBuffer.hpp> dependency. Everything should work as expected in the complete program.

Future steps:
- Calculate roll, yaw, and pitch and make sure the readings are reliable after calibration (I'm very interested on inspecting this).
- Consider a Kalman real-time filter to account for the distortions that a turned-on motor would produce on the readings. I tested this at home and it's quite problematic; the error is non-negligible under my pov. I'm willing to collaborate with @gungie-adam77 in case this isn't already achieved!

# Homemade test of a turned-on motor scenario 
(Turn ON the volume!) Tested placing the sensor on top of a kitchen extractor fan, it becomes clear how the readings may behave once the motor goes active. This may have greater or smaller influence depending on the distance of the motor to the device. As its seen, some readings get a error of almost ~15 points, representing a ~20% error margin.

https://github.com/user-attachments/assets/28b14e72-50c2-4054-a471-469453c8d420

![MotorOn](https://github.com/user-attachments/assets/05726164-439e-44f6-949b-be27c967f636)